### PR TITLE
24 decouple test authorization

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -4,9 +4,9 @@ from app.main import app
 from app.security import create_access_token
 
 
-def pytest_configure():
-    return {'last_created_tweet_id': 0,
-            'test_user_1_username': ''}
+def create_header(username):
+    token = create_access_token({'sub': username})
+    return {"Authorization": "Bearer %s" % token}   
 
 
 @pytest.fixture

--- a/app/tests/tweets/test_tweet_router.py
+++ b/app/tests/tweets/test_tweet_router.py
@@ -3,12 +3,7 @@ from fastapi import status
 import app.tests.tweets.tweet_cases as cases
 from app.security import create_access_token
 from app.schemas import TweetReturn
-from lorem_text import lorem
-
-
-def create_header(username):
-    token = create_access_token({'sub': username})
-    return {"Authorization": "Bearer %s" % token}   
+from app.tests.conftest import create_header
 
 
 def test_init(test_user_1):

--- a/app/tests/users/test_users_router.py
+++ b/app/tests/users/test_users_router.py
@@ -6,12 +6,7 @@ TODO test_invalid_patching(user) Try changing username or email
 import pytest
 from fastapi import status
 import app.tests.users.user_cases as cases
-from app.security import create_access_token
-
-
-def create_header(username):
-    token = create_access_token({'sub': username})
-    return {"Authorization": "Bearer %s" % token}
+from app.tests.conftest import create_header
 
 
 @pytest.mark.parametrize("user", cases.users)


### PR DESCRIPTION
Just a note not connected very directly with this PR: 
I just noticed inside the `conftest.py` there are a lot of remnants that are not being used anywhere (e.g. [authorized_client](https://github.com/Tzal3x/twitter_clone/blob/3cf5a3938f446ba8f53d15418d9e3ab78c3b80d9/app/tests/conftest.py#LL40C23-L40C23) fixture etc)