### PR TITLE
Fix - unable to access API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     depends_on:
       - web
     ports:
-      - "80:80"
+      - "80:8000"
 
   mongodb:
     image: "mongo:5.0"


### PR DESCRIPTION
The problem lied in the fact
that nginx was only exposing port 80
and in order for it to be connected with
the web container (our API) it should
map port 80 with port 8000.

i.e. to fix this we specify to nginx
"80:8000". This way port 80 is forwarded to
port 8000 which is the exposed port of
the web container.